### PR TITLE
Fix clang warnings

### DIFF
--- a/cserver.c
+++ b/cserver.c
@@ -239,19 +239,20 @@ int start_server(char* path, bool cli_mode) {
         cJSON_AddItemToObject(context, "config", config);
         cJSON_AddItemToObject(context, "site", site_metadata);
 
-        string content = string_init();
-        string response = string_init();
+        string response;
 
         if (path != NULL) {
             const char *content_type = get_content_type(url, path);
-            content = render_page(context, path);
+            string content = render_page(context, path);
             response = make_response(HTTP_STATUS_200, content_type, content);
+            string_free(content);
         } else {
             char *page_404_path = resource_path("/404");
             if (page_404_path != NULL) {
                 const char *content_type = get_content_type(url, page_404_path);
-                content = render_page(context, page_404_path);
+                string content = render_page(context, page_404_path);
                 response = make_response(HTTP_STATUS_404, content_type, content);
+                string_free(content);
             } else {
                 string not_found = string_make("File not found.");
                 response = make_response(HTTP_STATUS_404, "text/plain", not_found);
@@ -269,7 +270,6 @@ int start_server(char* path, bool cli_mode) {
             perror("send failed.\n");
             exit(EXIT_FAILURE);
         }
-        string_free(content);
         string_free(response);
 
         // Close the connection

--- a/cserver.c
+++ b/cserver.c
@@ -444,7 +444,9 @@ string make_response(char *http_status, const char *content_type, string content
     // Empty line to separate headers from the content
     strcat(response, "\r\n"); 
     // Content
-    strcat(response, content.value);
+    if (content.value) {
+        strcat(response, content.value);
+    }
 
     result.value = response;
     result.length = strlen(response);


### PR DESCRIPTION
Fixes warnings:
- Value stored to 'content' during its initialization is never read [deadcode.DeadStores]
- Null pointer passed as 2nd argument to string concatenation function